### PR TITLE
feat: make scan limits configurable

### DIFF
--- a/NiceThumbsBuddy.user.js
+++ b/NiceThumbsBuddy.user.js
@@ -6,7 +6,8 @@
 // @author       Archangel13GTL
 // @license      MIT
 // @run-at       document-end
-// @grant        none
+// @grant        GM_getValue
+// @grant        GM_setValue
 
 // Common media folders
 // @match        *://*/wp-content/uploads/*
@@ -41,10 +42,22 @@
   // --------------------------- Config --------------------------------------
   const IMG_EXT = /\.(avif|webp|jpe?g|png|gif|bmp|svg)$/i;
   const FILE_EXT = /\.(avif|webp|jpe?g|png|gif|bmp|svg|heic|tif?f|mp4|mov|webm|mkv|pdf|zip|rar|7z|tar|gz)$/i;
-  const MAX_ITEMS_PAGE = 12000; // per page safety guard
-  const SCAN_CONCURRENCY = 4;   // sitemap concurrent fetches
-  const IO_THRESHOLD = 0.1;     // intersection observer threshold
   const CACHE_EXPIRY = 7200000; // metadata cache expiry (2 hours)
+
+  // Preference helpers using GM_* if available, falling back to localStorage
+  const storage = (typeof GM_getValue === 'function' && typeof GM_setValue === 'function')
+    ? { get: GM_getValue, set: GM_setValue }
+    : {
+        get: (k) => localStorage.getItem(k),
+        set: (k, v) => localStorage.setItem(k, v)
+      };
+
+  const getPref = (key, def) => {
+    const v = storage.get(key);
+    return v !== undefined && v !== null ? v : def;
+  };
+
+  const setPref = (key, val) => storage.set(key, val);
 
   // Local storage keys
   const LSK = {
@@ -90,6 +103,11 @@
     n < 1073741824 ? `${(n / 1048576).toFixed(1)} MB` :
     `${(n / 1073741824).toFixed(2)} GB`
   );
+
+  // Configurable limits with validation
+  const MAX_ITEMS_PAGE = clamp(parseInt(getPref('ntb:maxitems', 12000), 10), 100, 50000); // per page safety guard
+  const SCAN_CONCURRENCY = clamp(parseInt(getPref('ntb:concurrency', 4), 10), 1, 16);    // sitemap concurrent fetches
+  const IO_THRESHOLD = clamp(parseFloat(getPref('ntb:iothreshold', 0.1)), 0, 1);         // intersection observer threshold
   
   // Shuffle array (for random sort)
   const shuffle = (array) => {
@@ -120,6 +138,30 @@
       return fn(...args);
     };
   };
+
+  // Add UI controls to adjust limits and persist them
+  function setupLimitControls() {
+    const poll = setInterval(() => {
+      const right = document.querySelector('.ntb-toolbar .ntb-right');
+      if (!right) return;
+      clearInterval(poll);
+      const btn = document.createElement('button');
+      btn.textContent = 'Limits';
+      btn.title = 'Adjust page limits and thresholds';
+      btn.addEventListener('click', () => {
+        const max = prompt('Max items per page (100-50000)', MAX_ITEMS_PAGE);
+        if (max !== null) setPref('ntb:maxitems', clamp(parseInt(max, 10) || MAX_ITEMS_PAGE, 100, 50000));
+        const conc = prompt('Scan concurrency (1-16)', SCAN_CONCURRENCY);
+        if (conc !== null) setPref('ntb:concurrency', clamp(parseInt(conc, 10) || SCAN_CONCURRENCY, 1, 16));
+        const thr = prompt('Intersection threshold (0-1)', IO_THRESHOLD);
+        if (thr !== null) setPref('ntb:iothreshold', clamp(parseFloat(thr) || IO_THRESHOLD, 0, 1));
+        location.reload();
+      });
+      right.appendChild(btn);
+    }, 500);
+  }
+
+  setupLimitControls();
 
   // Get file extension
   const getExt = (url) => {


### PR DESCRIPTION
## Summary
- allow tuning page item limit, scan concurrency, and observer threshold via persistent settings
- add 'Limits' button to toolbar that prompts for new values
- store preferences with `GM_setValue` or `localStorage` and clamp within safe ranges

## Testing
- `node -e "const fs=require('fs');new Function(fs.readFileSync('NiceThumbsBuddy.user.js','utf8'))"` *(fails: SyntaxError: Unexpected token ')' due to existing file truncation)*

------
https://chatgpt.com/codex/tasks/task_e_68aa157de28883288f17af5b8d65ed29